### PR TITLE
Update README about script splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Le fichier de configuration inclut :
   Configuration des sorties pour piloter les bobines.
 - **Scripts de contrôle :**
   Chaque script exécute la séquence de 8 demi-pas pour actionner le moteur (avec 512 demi-pas par défaut).
+  Pour éviter un blocage quand le nombre de pas est très élevé, la distribution est découpée en petits scripts asynchrones exécutés par tranches d'une trentaine de pas.
 - **Switches Template :**
   Permettent de lancer les scripts via Home Assistant.
 


### PR DESCRIPTION
## Summary
- mention that dosing scripts are split into small chunks
  to prevent large step counts from freezing execution

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a1ad96448330ab158c58c064e040