### PR TITLE
Update friendly name typo

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -13,7 +13,7 @@ packages:
 esphome:
   name: pompe_doseuses_esphome
   name_add_mac_suffix: false
-  friendly_name: "Pompes doseuses récifale"
+  friendly_name: "Pompes doseuses récifales"
   platformio_options:
     build_flags:
       - -DBROWNOUT_DISABLE


### PR DESCRIPTION
## Summary
- fix French pluralization of `friendly_name` in `install.yaml`

## Testing
- `grep -n friendly_name install.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68409fbff3108330b38225ccd4e450aa