### PR TITLE
test: add YAML syntax validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test YAML
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml
+pytest
+yamllint

--- a/tests/test_yaml_syntax.py
+++ b/tests/test_yaml_syntax.py
@@ -1,0 +1,15 @@
+import yaml
+from pathlib import Path
+import pytest
+
+# Recursively collect YAML files
+yaml_files = [
+    p for p in Path('.').rglob('*.yaml')
+    if '.git' not in p.parts and 'venv' not in p.parts and '.venv' not in p.parts
+]
+
+@pytest.mark.parametrize('yaml_path', yaml_files)
+def test_yaml_syntax(yaml_path):
+    with open(yaml_path, 'r', encoding='utf-8') as f:
+        yaml.safe_load(f)
+


### PR DESCRIPTION
## Summary
- add `pyyaml`, `pytest` and `yamllint` tooling
- create minimal YAML syntax test
- run tests in GitHub Actions

## Testing
- `pytest -v tests/test_yaml_syntax.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68409ff9873c83308600d7d8ffc588bb