### PR TITLE
Add pump speed level control

### DIFF
--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -423,6 +423,11 @@ globals:
     type: bool
     restore_value: true
     initial_value: 'false'
+  # Vitesse de la pompe (0=lent, 1=moyen, 2=rapide)
+  - id: pump1_speed_level
+    type: int
+    restore_value: true
+    initial_value: '1'
   - id: pump1_manual_dose_active
     type: bool
     restore_value: false
@@ -1515,10 +1520,12 @@ script:
             {1,0,0,1}
           };
           int dyn_delay = 2;
-          if (id(pump1_dose_ml) > 80)      dyn_delay = 0;
-          else if (id(pump1_dose_ml) > 40) dyn_delay = 1;
-          else if (id(pump1_dose_ml) > 15) dyn_delay = 2;
-          else                             dyn_delay = 3;
+          switch (id(pump1_speed_level)) {
+            case 0: dyn_delay = 5; break;
+            case 1: dyn_delay = 2; break;
+            case 2: dyn_delay = 0; break;
+            default: dyn_delay = 2; break;
+          }
           int max_chunk = 30;
           int start = id(pump1_step_index);
           int end = start + max_chunk;
@@ -1594,13 +1601,20 @@ script:
           int run_now = (remaining < max_chunk) ? remaining : max_chunk;
           int start = 0;
           int end = run_now;
+          int dyn_delay;
+          switch (id(pump1_speed_level)) {
+            case 0: dyn_delay = 5; break;
+            case 1: dyn_delay = 2; break;
+            case 2: dyn_delay = 0; break;
+            default: dyn_delay = 2; break;
+          }
           for (int i = start; i < end; i++) {
             int seq = i % 8;
             if (steps[seq][0]) id(pump1_coil1).turn_on(); else id(pump1_coil1).turn_off();
             if (steps[seq][1]) id(pump1_coil2).turn_on(); else id(pump1_coil2).turn_off();
             if (steps[seq][2]) id(pump1_coil3).turn_on(); else id(pump1_coil3).turn_off();
             if (steps[seq][3]) id(pump1_coil4).turn_on(); else id(pump1_coil4).turn_off();
-            delay(2);
+            delay(id(pump1_test_mode) ? 0 : dyn_delay);
           }
           id(pump1_priming_steps_remaining) -= run_now;
       - if:
@@ -1638,13 +1652,20 @@ script:
           int run_now = (remaining < max_chunk) ? remaining : max_chunk;
           int start = 0;
           int end = run_now;
+          int dyn_delay;
+          switch (id(pump1_speed_level)) {
+            case 0: dyn_delay = 5; break;
+            case 1: dyn_delay = 2; break;
+            case 2: dyn_delay = 0; break;
+            default: dyn_delay = 2; break;
+          }
           for (int i = start; i < end; i++) {
             int seq = i % 8;
             if (steps[seq][0]) id(pump1_coil1).turn_on(); else id(pump1_coil1).turn_off();
             if (steps[seq][1]) id(pump1_coil2).turn_on(); else id(pump1_coil2).turn_off();
             if (steps[seq][2]) id(pump1_coil3).turn_on(); else id(pump1_coil3).turn_off();
             if (steps[seq][3]) id(pump1_coil4).turn_on(); else id(pump1_coil4).turn_off();
-            delay(2);
+            delay(id(pump1_test_mode) ? 0 : dyn_delay);
           }
           id(pump1_calibration_steps_remaining) -= run_now;
       - if:
@@ -1745,6 +1766,29 @@ switch:
       - lambda: |-
           id(pump1_test_mode) = false;
           ESP_LOGI("pump", "Mode test désactivé");
+    web_server:
+      sorting_group_id: sorting_group_general
+
+  - platform: template
+    name: "Pompe 1 - Vitesse"
+    id: pump1_speed_select
+    icon: mdi:speedometer
+    entity_category: config
+    options:
+      - "Lent"
+      - "Moyen"
+      - "Rapide"
+    lambda: |-
+      int lvl = id(pump1_speed_level);
+      if (lvl == 0) return std::string("Lent");
+      else if (lvl == 1) return std::string("Moyen");
+      else return std::string("Rapide");
+    set_action:
+      - lambda: |-
+          if (x == "Lent") id(pump1_speed_level) = 0;
+          else if (x == "Moyen") id(pump1_speed_level) = 1;
+          else if (x == "Rapide") id(pump1_speed_level) = 2;
+          ESP_LOGD("pump", "Niveau de vitesse mis à %d", id(pump1_speed_level));
     web_server:
       sorting_group_id: sorting_group_general
 


### PR DESCRIPTION
## Summary
- add a global `pump1_speed_level`
- expose pump speed as a template select
- use the variable in `run_pump1_async_chunk`
- also apply speed variable in priming and calibration scripts

## Testing
- `yamllint common/pompe1.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c317ca688330bcfceb3dfc27abb0