### PR TITLE
Fix stepper initialization

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -23,7 +23,6 @@ esphome:
       - lambda: |-
           id(pump1_manual_dose_active) = false;
           ESP_LOGW("pump", "Remise à zéro de pump1_manual_dose_active au boot !");
-      - lambda: |-
           id(pump1_stepper).set_target_position(0);
           id(pump1_stepper).report_position(0);
 api:


### PR DESCRIPTION
## Summary
- simplify the `on_boot` lambda in `install.yaml` so ESPHome will work on older versions without the `stepper.report_position` action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ce95c360833088be0a03def91168