### PR TITLE
Fix invalid YAML due to missing lambda step

### DIFF
--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -1635,8 +1635,8 @@ script:
           ESP_LOGI("pump", "✅ Amorçage terminé.");
       - delay: 10ms
       - switch.turn_off: pump1_priming_switch
-
-          if (!id(pump1_enabled)) return;
+      - lambda: |-
+            if (!id(pump1_enabled)) return;
 
           // Récupération de l’heure actuelle
           auto now = id(my_time).now();


### PR DESCRIPTION
## Summary
- fix `priming_pump1_steps_fast` script by adding missing `lambda` step

## Testing
- `esphome compile install.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527ffeb3b88330a094f6a8a9f984c6