### PR TITLE
Fix priming pump speed

### DIFF
--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -1742,7 +1742,7 @@ switch:
           id(pump1_status).publish_state("Amorçage en cours…");
           // Pour 5 secondes d’amorçage, calculons le nombre de pas : 5s = 5000ms / 2ms par pas = 2500 pas
           id(pump1_priming_steps_remaining) = 2500;
-      - script.execute: priming_pump1_steps
+      - script.execute: priming_pump1_steps_fast
     web_server:
       sorting_group_id: sorting_group_calibration
   # Bouton pour lancer la calibration


### PR DESCRIPTION
## Summary
- speed up the pump priming routine by calling the fast priming script

## Testing
- `esphome compile pompedoseuses_config.yaml` *(fails: esphome: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852aa4d0b648330b79bb6b0d5937d40