### PR TITLE
Prevent pump run if reservoir empty

### DIFF
--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -1547,6 +1547,12 @@ script:
     mode: restart
     then:
       - lambda: |-
+          if (id(pump1_volume_remaining) <= 0) {
+            ESP_LOGW("pump", "⚠️ Volume insuffisant, distribution annulée.");
+            id(pump1_status).publish_state("Réservoir vide");
+            id(pump1_volume_remaining_sensor).publish_state(id(pump1_volume_remaining));
+            return;
+          }
           if (id(pump1_manual_dose_active)) {
             ESP_LOGW("pump", "⚠️ Une distribution est déjà en cours, exécution ignorée.");
             return;


### PR DESCRIPTION
## Summary
- protect `run_pump1_steps` from running when the reservoir volume is zero

## Testing
- `yamllint -v` *(fails: command not found)*
- `esphome version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569b9bd828833093ff244c82691908