### PR TITLE
Implement chunked pump steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Le fichier de configuration inclut :
   Configuration des sorties pour piloter les bobines.
 - **Scripts de contrôle :**
   Chaque script exécute la séquence de 8 demi-pas pour actionner le moteur (avec 512 demi-pas par défaut).
-  Pour éviter un blocage quand le nombre de pas est très élevé, la distribution est découpée en petits scripts asynchrones exécutés par tranches d'une trentaine de pas.
+  Pour éviter un blocage quand le nombre de pas est très élevé, la distribution est désormais découpée en petites tranches exécutées récursivement.
+  Chaque tranche met à jour les composants avec `component.update` afin de conserver l'état `pump1_manual_dose_active` cohérent durant toute l'exécution.
 - **Switches Template :**
   Permettent de lancer les scripts via Home Assistant.
 

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -439,6 +439,14 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: pump1_steps_remaining
+    type: int
+    restore_value: false
+    initial_value: '0'
+  - id: pump1_current_chunk
+    type: int
+    restore_value: false
+    initial_value: '0'
   - id: pump1_priming_steps_remaining
     type: int
     restore_value: false
@@ -1554,35 +1562,46 @@ script:
           float dose_ml = id(pump1_dose_ml);
           float factor = id(pump1_calibration_factor);
           id(pump1_steps_to_run) = (int)(dose_ml / factor);
+          id(pump1_steps_remaining) = id(pump1_steps_to_run);
           id(pump1_manual_dose_active) = true;
           id(pump1_status).publish_state("Distribution en cours…");
           ESP_LOGI("pump", "⚙️ Début distribution : %d pas", id(pump1_steps_to_run));
+      - script.execute: run_pump1_step_chunk
+  - id: run_pump1_step_chunk
+    mode: restart
+    then:
       - lambda: |-
+          if (id(pump1_steps_remaining) <= 0) {
+            char buffer[40];
+            auto now = id(my_time).now();
+            float dose_ml = id(pump1_dose_ml);
+            sprintf(buffer, "%04d-%02d-%02d %02d:%02d - %.1f ml", now.year, now.month, now.day_of_month, now.hour, now.minute, dose_ml);
+            id(pump1_distributed_today) += dose_ml;
+            id(pump1_used_today) += dose_ml;
+            id(pump1_volume_remaining) = std::max(0.0f, id(pump1_volume_remaining) - dose_ml);
+            id(pump1_volume_remaining_sensor).publish_state(id(pump1_volume_remaining));
+            id(pump1_last_dose_log) = buffer;
+            id(pump1_last_dose_text).update();
+            id(pump1_manual_dose_active) = false;
+            id(pump1_status).publish_state("Prêt");
+            ESP_LOGI("pump", "✅ Distribution manuelle terminée.");
+            return;
+          }
+          int chunk = id(pump1_steps_remaining) > 30 ? 30 : id(pump1_steps_remaining);
           int lvl = id(pump1_speed_level);
           int speed = 500;
           if (lvl == 0) speed = 300;
           else if (lvl == 2) speed = 700;
           id(pump1_stepper).set_max_speed(speed);
           id(pump1_current_speed) = speed;
+          id(pump1_current_chunk) = chunk;
+          id(pump1_steps_remaining) -= chunk;
       - stepper.set_target:
           id: pump1_stepper
-          target: !lambda 'return id(pump1_stepper).current_position + id(pump1_steps_to_run);'
-      - delay: !lambda 'return (id(pump1_steps_to_run) * 1.0f) / id(pump1_current_speed);'
-      # - stepper.deenergize: pump1_stepper
-      - lambda: |-
-          char buffer[40];
-          auto now = id(my_time).now();
-          float dose_ml = id(pump1_dose_ml);
-          sprintf(buffer, "%04d-%02d-%02d %02d:%02d - %.1f ml", now.year, now.month, now.day_of_month, now.hour, now.minute, dose_ml);
-          id(pump1_distributed_today) += dose_ml;
-          id(pump1_used_today) += dose_ml;
-          id(pump1_volume_remaining) = std::max(0.0f, id(pump1_volume_remaining) - dose_ml);
-          id(pump1_volume_remaining_sensor).publish_state(id(pump1_volume_remaining));
-          id(pump1_last_dose_log) = buffer;
-          id(pump1_last_dose_text).update();
-          id(pump1_manual_dose_active) = false;
-          id(pump1_status).publish_state("Prêt");
-          ESP_LOGI("pump", "✅ Distribution manuelle terminée.");
+          target: !lambda 'return id(pump1_stepper).current_position + id(pump1_current_chunk);'
+      - delay: !lambda 'return (id(pump1_current_chunk) * 1.0f) / id(pump1_current_speed);'
+      - component.update: pump1_volume_remaining_sensor
+      - script.execute: run_pump1_step_chunk
   - id: refresh_daily_quantity_sensor
     mode: queued
     then:


### PR DESCRIPTION
## Summary
- break `run_pump1_steps` into a recursive chunked script
- keep `pump1_manual_dose_active` consistent during execution
- document the new approach in README

## Testing
- `yamllint common/pompe1.yaml` *(fails: command not found)*
- `esphome compile install.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569bb489a08330b4058d02207007e7