### PR TITLE
Add pump speed selector to Lovelace

### DIFF
--- a/Config HA/Lovelace card
+++ b/Config HA/Lovelace card
@@ -64,6 +64,11 @@ cards:
         name: Mode
         icon: mdi:format-list-bulleted
         icon_color: lime
+      - type: custom:mushroom-select-card
+        entity: select.pompe_doseuses_esphome_pompe_1_vitesse
+        name: Vitesse
+        icon: mdi:speedometer
+        icon_color: cyan
   - type: custom:state-switch
     entity: select.pompe_doseuses_esphome_pompe_1_mode_de_distribution
     default: Autre
@@ -539,3 +544,13 @@ cards:
         name: SSID WiFi
       - entity: sensor.pompe_doseuses_esphome_i2c_devices_connected
         name: Périphériques I2C
+      - entity: sensor.pompe_doseuses_esphome_adresse_ip_esp32
+        name: Adresse IP
+      - entity: sensor.pompe_doseuses_esphome_temperature_interne
+        name: Température interne
+      - entity: sensor.pompe_doseuses_esphome_force_du_signal_wifi
+        name: Force du signal WiFi
+      - entity: sensor.pompe_doseuses_esphome_esp32_hall_sensor
+        name: ESP32 Hall Sensor
+      - entity: sensor.pompe_doseuses_esphome_device_info
+        name: Device Info


### PR DESCRIPTION
## Summary
- expose `select.pompe_doseuses_esphome_pompe_1_vitesse` on the Lovelace dashboard

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68579addc1c48330a8497889e58ff62c