### PR TITLE
Add pump history reset button

### DIFF
--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -1902,6 +1902,24 @@ button:
             id(pump1_volume_remaining_sensor).publish_state(id(pump1_volume_remaining));
             ESP_LOGI("pump", "Réservoir remis à %.0f ml", id(pump1_reservoir_capacity));
 
+  - platform: template
+    name: "Réinitialiser Historique Pompe 1"
+    id: pump1_reset_history_button
+    entity_category: diagnostic
+    icon: mdi:history
+    on_press:
+      then:
+        - lambda: |-
+            id(pump1_used_today) = 0.0;
+            id(pump1_distributed_today) = 0.0;
+            id(pump1_last_dose_log) = "Jamais";
+            id(pump1_used_today_sensor).publish_state(id(pump1_used_today));
+            id(pump1_distributed_today_sensor).publish_state(id(pump1_distributed_today));
+            id(pump1_last_dose_text).update();
+            ESP_LOGI("pump", "Historique pompe 1 réinitialisé.");
+    web_server:
+      sorting_group_id: sorting_group_calibration
+
 interval:
   - interval: 60s
     then:


### PR DESCRIPTION
## Summary
- add a new template button to reset the daily pump history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857b6a9e460833086c8924284a709ab