### PR TITLE
Replace calibration switches with buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,19 +307,19 @@ Cette option permet de mieux identifier les pompes et leurs fonctions spécifiqu
 
 3. **Validation et Suivi**
    - Consultez les logs ESPHome (`Logs en direct`) pour vérifier l'exécution des doses.
-   - Activez `Valider Calibration Pompe X` après une calibration pour mettre à jour les paramètres internes.
+   - Appuyez sur le bouton `Valider Calibration Pompe X` après une calibration pour mettre à jour les paramètres internes.
    - Vérifiez régulièrement la précision des doses et ajustez la calibration si nécessaire.
 
 ### Calibration et enregistrement du facteur
 
 Lors de la calibration, vous pouvez mesurer le volume réellement délivré (ex. dans une seringue graduée), puis saisir cette valeur dans le champ **"Pompe X - Volume mesuré (ml)"**.
 
-Ensuite, cliquez sur **"Valider Calibration Pompe X"** pour enregistrer le nouveau facteur (ml/pas), automatiquement calculé.
+Ensuite, appuyez sur **"Valider Calibration Pompe X"** pour enregistrer le nouveau facteur (ml/pas), automatiquement calculé.
 
 Ce facteur sera utilisé dans tous les modes pour déterminer la quantité à distribuer.
 
-> ⚠️ Le lancement de la calibration est bloqué si les switches "Amorcer" ou "Valider Calibration" sont actifs.
-> Ces actions sont exclusives afin d’éviter les conflits moteurs. Chaque switch revient automatiquement à l'état OFF une fois son action terminée.
+> ⚠️ Le lancement de la calibration est bloqué si le switch "Amorcer" est actif.
+> Ces actions sont exclusives afin d’éviter les conflits moteurs.
 
 ### Conseils d'Utilisation
 - Pour garantir la fiabilité du système, testez chaque mode avant de l'appliquer en condition réelle.

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -1677,7 +1677,6 @@ script:
           id(pump1_status).publish_state("Prêt");
           ESP_LOGI("pump", "✅ Calibration terminée.");
       - delay: 10ms
-      - switch.turn_off: pump1_start_calibration_switch
   #-------------------------------------
   # SCRIPT D'AMORÇAGE : vitesse rapide
   #-------------------------------------
@@ -1813,35 +1812,6 @@ switch:
       - switch.turn_off: pump1_priming_switch
     web_server:
       sorting_group_id: sorting_group_calibration
-  # Bouton pour lancer la calibration
-  - platform: template
-    name: "Lancer Calibration Pompe 1"
-    id: pump1_start_calibration_switch
-    entity_category: diagnostic
-    lambda: return false;
-    turn_on_action:
-      - lambda: |-
-          ESP_LOGD("pump", "Lancement de la calibration (mode asynchrone)...");
-          id(pump1_status).publish_state("Calibration en cours…");
-          // Lance la calibration sur le nombre de pas configuré
-          id(pump1_calibration_steps_remaining) = id(pump1_calibration_steps);
-      - script.execute: calibration_pump1_steps
-    web_server:
-      sorting_group_id: sorting_group_calibration  # ou diagnostic, misc, etc.
-  # Bouton pour valider la calibration
-  - platform: template
-    name: "Valider Calibration Pompe 1"
-    id: pump1_validate_calibration_switch
-    entity_category: diagnostic
-    lambda: return false;
-    turn_on_action:
-      - lambda: |-
-          id(pump1_calibration_factor) = id(pump1_calibration_value) / id(pump1_calibration_steps);
-          id(pump1_last_calibration) = id(my_time).now().timestamp;
-          ESP_LOGW("pump", "Calibration validée: facteur = %.4f ml/step", id(pump1_calibration_factor));
-      - switch.turn_off: pump1_validate_calibration_switch
-    web_server:
-      sorting_group_id: sorting_group_calibration  # ou diagnostic, misc, etc.
   # Mode de test
   - platform: template
     name: "🧪 Mode Test / Simulation"
@@ -1861,6 +1831,34 @@ switch:
       sorting_group_id: sorting_group_general
 
 button:
+  # Bouton pour lancer la calibration
+  - platform: template
+    name: "Lancer Calibration Pompe 1"
+    id: pump1_start_calibration_button
+    entity_category: diagnostic
+    on_press:
+      then:
+        - lambda: |-
+            ESP_LOGD("pump", "Lancement de la calibration (mode asynchrone)...");
+            id(pump1_status).publish_state("Calibration en cours…");
+            // Lance la calibration sur le nombre de pas configuré
+            id(pump1_calibration_steps_remaining) = id(pump1_calibration_steps);
+        - script.execute: calibration_pump1_steps
+    web_server:
+      sorting_group_id: sorting_group_calibration  # ou diagnostic, misc, etc.
+  # Bouton pour valider la calibration
+  - platform: template
+    name: "Valider Calibration Pompe 1"
+    id: pump1_validate_calibration_button
+    entity_category: diagnostic
+    on_press:
+      then:
+        - lambda: |-
+            id(pump1_calibration_factor) = id(pump1_calibration_value) / id(pump1_calibration_steps);
+            id(pump1_last_calibration) = id(my_time).now().timestamp;
+            ESP_LOGW("pump", "Calibration validée: facteur = %.4f ml/step", id(pump1_calibration_factor));
+    web_server:
+      sorting_group_id: sorting_group_calibration  # ou diagnostic, misc, etc.
   - platform: template
     name: "Doser manuellement Pompe 1"
     id: pump1_manual_dose_button


### PR DESCRIPTION
## Summary
- convert calibration triggers from switches to buttons
- update logs and README accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857d9647ef88330b0d8b9262abbb613