### PR TITLE
Fix infinite pump loop during manual dose

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Le fichier de configuration inclut :
   Chaque script exécute la séquence de 8 demi-pas pour actionner le moteur (avec 512 demi-pas par défaut).
   Pour éviter un blocage quand le nombre de pas est très élevé, la distribution est désormais découpée en petites tranches exécutées récursivement.
   Chaque tranche met à jour les composants avec `component.update` afin de conserver l'état `pump1_manual_dose_active` cohérent durant toute l'exécution.
+  Le script attend désormais la fin du mouvement du moteur avec `wait_until` pour éviter les boucles infinies lorsque la vitesse est trop lente.
 - **Switches Template :**
   Permettent de lancer les scripts via Home Assistant.
 

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -447,6 +447,11 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  # Position cible du mouvement en cours
+  - id: pump1_chunk_target
+    type: int
+    restore_value: false
+    initial_value: '0'
   - id: pump1_priming_steps_remaining
     type: int
     restore_value: false
@@ -1607,10 +1612,13 @@ script:
           id(pump1_current_speed) = speed;
           id(pump1_current_chunk) = chunk;
           id(pump1_steps_remaining) -= chunk;
+          id(pump1_chunk_target) = id(pump1_stepper).current_position + id(pump1_current_chunk);
       - stepper.set_target:
           id: pump1_stepper
-          target: !lambda 'return id(pump1_stepper).current_position + id(pump1_current_chunk);'
-      - delay: !lambda 'return (id(pump1_current_chunk) * 1.0f) / id(pump1_current_speed);'
+          target: !lambda 'return id(pump1_chunk_target);'
+      - wait_until:
+          condition:
+            lambda: 'return id(pump1_stepper).current_position >= id(pump1_chunk_target);'
       - component.update: pump1_volume_remaining_sensor
       - script.execute: run_pump1_step_chunk
   - id: refresh_daily_quantity_sensor


### PR DESCRIPTION
## Summary
- wait for each chunk to finish before starting the next
- document wait step in README

## Testing
- `yamllint -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e14380248330ae3b5c16fa4d9311