### PR TITLE
Update calibration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,11 @@ Cette option permet de mieux identifier les pompes et leurs fonctions spécifiqu
 
 ### Calibration et enregistrement du facteur
 
-Lors de la calibration, vous pouvez mesurer le volume réellement délivré (ex. dans une seringue graduée), puis saisir cette valeur dans le champ **"Pompe X - Volume mesuré (ml)"**.
+Lors de la calibration, la pompe effectue par défaut **60 000 pas**, soit environ une minute de fonctionnement. Vous pouvez augmenter ce nombre (par exemple à 120 000 pas pour deux minutes) via le paramètre **"Pompe 1 - Nombre de pas pendant la calibration"** afin d'obtenir un volume plus important.
 
-Ensuite, appuyez sur **"Valider Calibration Pompe X"** pour enregistrer le nouveau facteur (ml/pas), automatiquement calculé.
+Mesurez ensuite le volume réellement délivré (ex. dans une seringue graduée) et saisissez cette valeur dans le champ **"Pompe X - Volume mesuré (ml)"**.
+
+Appuyez enfin sur **"Valider Calibration Pompe X"** pour enregistrer le nouveau facteur (ml/pas), calculé automatiquement.
 
 Ce facteur sera utilisé dans tous les modes pour déterminer la quantité à distribuer.
 

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -88,7 +88,7 @@ globals:
   - id: pump1_calibration_steps
     type: int
     restore_value: true
-    initial_value: '10000'  # Nombre de pas pendant la calibration (par défaut : 10 000 pas pour une meilleure précision)
+    initial_value: '60000'  # Nombre de pas pendant la calibration (environ 1 minute de fonctionnement)
   - id: pump1_calibration_factor
     type: float
     restore_value: true


### PR DESCRIPTION
## Summary
- expand calibration instructions in README
- increase default calibration duration to roughly a minute

## Testing
- `yamllint common/pompe1.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3251a910833095042aa38783478e