### PR TITLE
Mode 3: deterministic per-period dose indexing and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ La logique de distribution dans le Mode 3 utilise ces paramètres pour ne décle
 2. Chaque période est caractérisée par une **heure de début et une heure de fin**.
 3. L’utilisateur définit **le nombre de doses** à injecter pendant chaque période.
 4. La dose quotidienne totale est **répartie entre ces doses**.
+5. Le déclenchement des doses se base sur un **index de dose** calculé par rapport au temps écoulé dans la période (progression normalisée sur la durée). Cela garantit **exactement N doses** pour une période donnée, même si la durée ne tombe pas juste en minutes (ex. 20 ml en 5 doses n’aboutit plus à 6 doses). 
 
 #### **Exemple de configuration :**
 | Période  | Horaire           | Nombre de doses |

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -2281,7 +2281,7 @@ interval:
             bool enabled[6]    = {id(${pump_id}_period1_enabled), id(${pump_id}_period2_enabled),
                                    id(${pump_id}_period3_enabled), id(${pump_id}_period4_enabled),
                                    id(${pump_id}_period5_enabled), id(${pump_id}_period6_enabled)};
-            static int last_minute[6] = {-1, -1, -1, -1, -1, -1};
+            static int last_index[6] = {-1, -1, -1, -1, -1, -1};
 
             int now_min = current_hour * 60 + current_minute;
 
@@ -2301,12 +2301,13 @@ interval:
               if (n <= 0 || end <= start) continue;
               // Fin de période exclusive pour garantir exactement N doses
               if (now_min >= start && now_min < end) {
-                int interval = (end - start) / n;
-                if (interval <= 0) interval = 1;
-                if (((now_min - start) % interval) == 0 && last_minute[i] != now_min) {
-                  last_minute[i] = now_min;
+                int duration = end - start;
+                int elapsed = now_min - start;
+                int index = (elapsed * n) / duration;
+                if (index < n && index != last_index[i]) {
+                  last_index[i] = index;
                   id(${pump_id}_dose_ml) = ml_per_dose;
-                  ESP_LOGD("pump", "Dose période %d à %02d:%02d : %.2f ml", i + 1, current_hour, current_minute, id(${pump_id}_dose_ml));
+                  ESP_LOGD("pump", "Dose période %d (%d/%d) à %02d:%02d : %.2f ml", i + 1, index + 1, n, current_hour, current_minute, id(${pump_id}_dose_ml));
                   if (id(${pump_id}_test_mode)) {
                     ESP_LOGI("pump", "🧪 [Test] Simulation dose Mode 3 période %d", i + 1);
                     id(${pump_id}_distributed_today) += id(${pump_id}_dose_ml);


### PR DESCRIPTION
### Motivation
- Fix an issue where Mode 3 (custom periods) could emit an incorrect number of doses by relying on a modulo-by-interval approach that sometimes produced extra firings. 
- Make the behavior explicit in the documentation so users understand the deterministic indexing used to guarantee exactly `N` doses per period.

### Description
- Replace the `last_minute` sentinel with `last_index` and map elapsed time to a dose slot with `index = (elapsed * n) / duration` to deterministically produce exactly `n` doses for a period. 
- Trigger a dose only when `index < n` and `index != last_index[i]`, then set `id(${pump_id}_dose_ml)` and update `last_index[i]`, preserving existing `test_mode` and `run_${pump_id}_steps` behaviors. 
- Improve the debug log to include the per-period dose index (`"Dose période %d (%d/%d) ..."`) for easier troubleshooting. 
- Add a README note explaining the dose-index calculation and that it guarantees exactly `N` doses per period.

### Testing
- No automated tests were run for these changes (documentation and deterministic indexing logic only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976193ae49c8330b9f1b940a4a3b1db)