### PR TITLE
Calibration dynamique : viser 4–5 ml et explications dans le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,9 @@ Cette option permet de mieux identifier les pompes et leurs fonctions spécifiqu
 
 ### Calibration et enregistrement du facteur
 
-Lors de la calibration, la pompe effectue par défaut **120 000 pas** configurés, et le script utilise **2× ce nombre** (soit **240 000 pas** en HALF_STEP), soit environ deux minutes de fonctionnement. Vous pouvez augmenter ce nombre (par exemple à 180 000 pas, soit 360 000 pas effectifs) via le paramètre **"Pompe 1 - Nombre de pas pendant la calibration"** afin d'obtenir un volume plus important.
+Lors de la calibration, la pompe **calcule désormais dynamiquement** le nombre de pas pour viser un volume **compris entre 4 et 5 ml**, en s'appuyant sur le **dernier facteur de calibration (ml/pas)** connu. Concrètement, au moment du lancement, la logique estime combien de pas sont nécessaires pour atteindre ~4,5 ml et ajuste automatiquement le nombre de pas utilisés par le script (le run total reste basé sur **2× ce nombre**, en HALF_STEP). Cette approche garantit un volume suffisamment faible pour être mesuré précisément, tout en restant stable d'une calibration à l'autre.
+
+Si le facteur de calibration est invalide ou inconnu (≤ 0), le système retombe sur la valeur configurée **"Pompe 1 - Nombre de pas pendant la calibration"** (par défaut **120 000 pas**, soit **240 000 pas effectifs**) afin d'éviter un comportement bloquant.
 
 Mesurez ensuite le volume réellement délivré (ex. dans une seringue graduée) et saisissez cette valeur dans le champ **"Pompe X - Volume mesuré (ml)"**.
 

--- a/common/pompe1.yaml
+++ b/common/pompe1.yaml
@@ -2090,8 +2090,29 @@ button:
             }
             ESP_LOGI("pump", "Lancement de la calibration (mode asynchrone)...");
             id(${pump_id}_status).publish_state("Calibration en cours…");
-            // Lance la calibration sur le nombre de pas configuré
+            // Ajuste dynamiquement la calibration pour viser 4-5 ml selon le facteur courant
+            float factor = id(${pump_id}_calibration_factor);
+            if (factor <= 0.0f) {
+              ESP_LOGW("pump", "⚠️ Calibration: facteur invalide, utilisation des pas configurés.");
+              id(${pump_id}_calibration_steps_remaining) = id(${pump_id}_calibration_steps) * 2;
+              return;
+            }
+            const float min_target_ml = 4.0f;
+            const float max_target_ml = 5.0f;
+            int min_steps = (int) ceilf(min_target_ml / factor);
+            int max_steps = (int) floorf(max_target_ml / factor);
+            int target_steps = 0;
+            if (max_steps >= min_steps && max_steps > 0) {
+              target_steps = std::max(min_steps, std::min(max_steps, (int) ceilf(4.5f / factor)));
+            } else {
+              ESP_LOGW("pump", "⚠️ Calibration: intervalle 4-5 ml impossible (facteur=%.6f), ajustement au plus proche.", factor);
+              target_steps = std::max(1, min_steps);
+            }
+            int base_steps = (int) ceilf(target_steps / 2.0f);
+            id(${pump_id}_calibration_steps) = std::max(1, base_steps);
             id(${pump_id}_calibration_steps_remaining) = id(${pump_id}_calibration_steps) * 2;
+            float estimated_ml = id(${pump_id}_calibration_steps_remaining) * factor;
+            ESP_LOGI("pump", "Calibration dynamique: %d pas (~%.2f ml).", id(${pump_id}_calibration_steps_remaining), estimated_ml);
         - script.execute: calibration_${pump_id}_steps
     web_server:
       sorting_group_id: sorting_group_calibration  # ou diagnostic, misc, etc.


### PR DESCRIPTION
### Motivation
- Rendre la calibration plus précise en visant systématiquement un volume mesurable (entre 4 et 5 ml) plutôt que d'utiliser un nombre fixe de pas.
- Documenter le nouveau comportement et le repli en cas de facteur de calibration invalide pour faciliter la compréhension et l'utilisation. 

### Description
- Modification de `common/pompe1.yaml` pour remplacer le lancement de calibration fixe par un calcul dynamique qui lit `id(${pump_id}_calibration_factor)` et estime le nombre de pas nécessaires pour viser ~4,5 ml. 
- Gestion du cas `factor <= 0` avec repli sur la valeur configurée `id(${pump_id}_calibration_steps)` et journalisation via `ESP_LOGW`. 
- Calcul des bornes `min_steps`/`max_steps` avec `ceilf`/`floorf`, sélection d'un `target_steps` proche de 4.5 ml, conversion en `calibration_steps` par demi-run (`ceil(target/2)`) et écriture de `calibration_steps_remaining = calibration_steps * 2` avant de lancer le script `calibration_${pump_id}_steps`, ainsi qu'un `ESP_LOGI` affichant l'estimation en ml. 
- Mise à jour de `README.md` pour expliquer le ciblage dynamique 4–5 ml, le calcul basé sur le `calibration_factor`, et la stratégie de repli vers la valeur configurée si le facteur est invalide. 

### Testing
- Aucun test automatisé n'a été exécuté sur ces changements (mise à jour fonctionnelle et documentation uniquement).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e1331e788330975b919a689720db)